### PR TITLE
Fix autocast v fp16  + add benchmark config instructions in benchmark.md

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -103,10 +103,21 @@ export ACCESS_TOKEN=<hf_...>
 
 #### Usage
 
+**Run benchmark on GPU (if available)**
 Launch the `benchmark.py` script to append benchmark results to the existing [benchmark.csv](../benchmark.csv) results file:
 ```
 python ./scripts/benchmark.py
 ```
+
+**Run benchmark on CPU**
+
+In order to run the benchmark on your CPU device, prefix the script run command with `CUDA_VISIBLE_DEVICES=` like so:
+```
+export CUDA_VISIBLE_DEVICES=
+python ./scripts/benchmark.py
+```
+
+**Benchmark config options**
 
 Here are the following flags that can be set on the `benchmark.py` script:
 * `--samples` sets the sample size for which to run a benchmark and is passed as a comma separated list of values such as `1,2,4,8,16`. Default is `1`.
@@ -118,6 +129,8 @@ An example of running the benchmark script options set:
 ```
 python ./scripts/benchmark.py --samples=1,2,4 --steps=50 --repeats=3 --autocast=no
 ```
+
+**Compare output of single-precision and half-precision**
 
 Launch the `benchmark_quality.py` script to compare the output of single-precision and half-precision models:
 ```

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -108,7 +108,18 @@ Launch the `benchmark.py` script to append benchmark results to the existing [be
 python ./scripts/benchmark.py
 ```
 
-Lauch the `benchmark_quality.py` script to compare the output of single-precision and half-precision models:
+Here are the following flags that can be set on the `benchmark.py` script:
+* `--samples` sets the sample size for which to run a benchmark and is passed as a comma separated list of values such as `1,2,4,8,16`. Default is `1`.
+* `--steps` sets the number of inference steps and is passed as an integer value, eg: `50`. Default is `40`.
+* `--repeats` sets the number of times to repeat each run with a given set of parameter value before reporting their average inference latencies. It is passed as an integer value, eg: `2`. Default is `3`.
+* `--autocast` sets whether or not to add cuda autocast runs to the benchmark (respectively `yes` and `no`). Default is `no`.
+
+An example of running the benchmark script options set:
+```
+python ./scripts/benchmark.py --samples=1,2,4 --steps=50 --repeats=3 --autocast=no
+```
+
+Launch the `benchmark_quality.py` script to compare the output of single-precision and half-precision models:
 ```
 python ./scripts/benchmark_quality.py
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 --extra-index-url https://download.pytorch.org/whl/cu116 torch
 
-torchvision==0.13.1
-torch==1.12.1
 transformers==4.22.1
 ftfy==6.1.1
 Pillow==9.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cu116 torch
 
+torchvision==0.13.1
+torch==1.12.1
 transformers==4.22.1
 ftfy==6.1.1
 Pillow==9.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ torch==1.12.1
 transformers==4.22.1
 ftfy==6.1.1
 Pillow==9.2.0
-diffusers==0.3.0
+diffusers==0.4.2
 onnxruntime==1.12.1
 scikit-image==0.19.3
 -e .

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -181,11 +181,9 @@ def run_benchmark_grid(grid, n_repeats, num_inference_steps):
         device_desc = get_device_description()
         for n_samples in grid["n_samples"]:
             for precision in grid["precision"]:
-                use_autocast = False
                 if precision == "half":
                     for autocast in grid["autocast"]:
-                        if autocast == "yes":
-                            use_autocast = True
+                        use_autocast = (autocast == "yes")
                         for backend in grid["backend"]:
                             try:
                                 new_log = run_benchmark(

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -182,40 +182,41 @@ def run_benchmark_grid(grid, n_repeats, num_inference_steps):
         for n_samples in grid["n_samples"]:
             for precision in grid["precision"]:
                 if precision == "half":
-                    for autocast in grid["autocast"]:
-                        use_autocast = (autocast == "yes")
-                        for backend in grid["backend"]:
-                            try:
-                                new_log = run_benchmark(
-                                    n_repeats=n_repeats,
-                                    n_samples=n_samples,
-                                    precision=precision,
-                                    use_autocast=use_autocast,
-                                    backend=backend,
-                                    num_inference_steps=num_inference_steps,
-                                )
-                            except Exception as e:
-                                if "CUDA out of memory" in str(
-                                    e
-                                ) or "Failed to allocate memory" in str(e):
-                                    print(str(e))
-                                    torch.cuda.empty_cache()
-                                    new_log = {"latency": -1.00, "memory": -1.00}
-                                else:
-                                    raise e
+                    use_autocast = (autocast == "yes")
+                else:
+                    use_autocast = False
+                for backend in grid["backend"]:
+                    try:
+                        new_log = run_benchmark(
+                            n_repeats=n_repeats,
+                            n_samples=n_samples,
+                            precision=precision,
+                            use_autocast=use_autocast,
+                            backend=backend,
+                            num_inference_steps=num_inference_steps,
+                        )
+                    except Exception as e:
+                        if "CUDA out of memory" in str(
+                            e
+                        ) or "Failed to allocate memory" in str(e):
+                            print(str(e))
+                            torch.cuda.empty_cache()
+                            new_log = {"latency": -1.00, "memory": -1.00}
+                        else:
+                            raise e
 
-                            latency = new_log["latency"]
-                            memory = new_log["memory"]
-                            new_row = [
-                                device_desc,
-                                precision,
-                                autocast,
-                                backend,
-                                n_samples,
-                                latency,
-                                memory,
-                            ]
-                            writer.writerow(new_row)
+                    latency = new_log["latency"]
+                    memory = new_log["memory"]
+                    new_row = [
+                        device_desc,
+                        precision,
+                        autocast,
+                        backend,
+                        n_samples,
+                        latency,
+                        memory,
+                    ]
+                    writer.writerow(new_row)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Fixed conditional logic when using autocast in benchmark code.
* Updated diffusers==0.3.0 to diffusers==0.4.2
* @chuanli11 : Any reason to not include torch and torchvision in the requirements?

**Removing autocast does seem to reduce the latency and memory in a big way!**
Here is what the new benchmark results for autocast v fp16 look like.

|device          |precision|autocast|runtime|n_samples|latency|memory|
|----------------|---------|--------|-------|---------|-------|------|
|NVIDIA RTX A6000|single   |False   |pytorch|1        |7.37   |7.73  |
|NVIDIA RTX A6000|half     |True    |pytorch|1        |4.39   |4.52  |
|NVIDIA RTX A6000|half     |False   |pytorch|1        |3.34   |3.38  |
|NVIDIA RTX A6000|single   |False   |pytorch|2        |14.0   |9.57  |
|NVIDIA RTX A6000|half     |True    |pytorch|2        |8.29   |8.74  |
|NVIDIA RTX A6000|half     |False   |pytorch|2        |6.17   |4.92  |
|NVIDIA RTX A6000|single   |False   |pytorch|4        |27.25  |18.4  |
|NVIDIA RTX A6000|half     |True    |pytorch|4        |15.73  |11.4  |
|NVIDIA RTX A6000|half     |False   |pytorch|4        |11.59  |8.82  |


Also added benchmark config instructions in benchmark.md
